### PR TITLE
Add `ontotools dir normalize` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         run: pip install .
 
       - name: Run tests
-        run: pytest --cov=ontotools tests/
+        run: python -m pytest --cov=ontotools tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Install dev dependencies
+        run: pip install -r requirements.dev.txt
+
       - name: Install ontotools
         run: pip install .
 
@@ -33,4 +36,4 @@ jobs:
         run: pip install pytest
 
       - name: Run tests
-        run: pytest
+        run: pytest --cov=src tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,5 @@ jobs:
       - name: Install ontotools
         run: pip install .
 
-      - name: Install pytet
-        run: pip install pytest
-
       - name: Run tests
-        run: pytest --cov=src tests/
+        run: pytest --cov=ontotools tests/

--- a/ontotools/cli.py
+++ b/ontotools/cli.py
@@ -1,8 +1,9 @@
 import typer
 
-from ontotools.commands import file, version
+from ontotools.commands import file, version, directory
 
 
 app = typer.Typer()
 app.add_typer(file.app, name="file")
 app.add_typer(version.app, name="version")
+app.add_typer(directory.app, name="dir")

--- a/ontotools/commands/directory.py
+++ b/ontotools/commands/directory.py
@@ -1,0 +1,23 @@
+import sys
+
+import typer
+
+from ontotools.functions.normalize_dir import normalize_dir, FailOnChangeError
+from ontotools.logging import logger
+
+app = typer.Typer()
+
+
+@app.command()
+def normalize(
+    directory: str = typer.Argument(
+        ..., help="The directory of Turtle files to be normalized"
+    ),
+    fail_if_changed: bool = typer.Option(False, help="Fail if files would changed"),
+):
+    """Normalizes the format of Turtle files in a given directory."""
+    try:
+        normalize_dir(directory, fail_if_changed)
+    except FailOnChangeError as err:
+        logger.error(err)
+        sys.exit(1)

--- a/ontotools/functions/normalize_dir.py
+++ b/ontotools/functions/normalize_dir.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from ontotools.functions.normalize_file import normalize_file, FailOnChangeError
+from ontotools.logging import logger
+
+
+def normalize_dir(path: Path, fail_if_changed: bool):
+    path = Path(path).resolve()
+
+    files = list(path.glob("**/*.ttl"))
+
+    changed_files = []
+
+    for file in files:
+        try:
+            changed = normalize_file(file, fail_if_changed, False)
+
+            if changed:
+                changed_files.append(file)
+        except FailOnChangeError:
+            changed_files.append(file)
+
+    if fail_if_changed:
+        raise FailOnChangeError(
+            f"{len(changed_files)} out of {len(files)} files will change."
+        )
+    else:
+        logger.info("%s out of %s files changed.", len(changed_files), len(files))

--- a/ontotools/functions/normalize_file.py
+++ b/ontotools/functions/normalize_file.py
@@ -1,0 +1,63 @@
+import pathlib
+
+from rdflib import Graph
+
+from ontotools.logging import logger
+from ontotools.functions.normalize import normalize
+from ontotools.utils import get_filename_without_extension
+
+
+class FailOnChangeError(Exception):
+    """File changed due to normalization function."""
+
+    pass
+
+
+def normalize_file(
+    filename: pathlib.Path,
+    fail_if_changed: bool,
+    generate_formats: bool,
+    output_filename: pathlib.Path = None,
+) -> bool:
+    # Ensure the file exists.
+    path = pathlib.Path(filename).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path.absolute()}")
+
+    with open(path, "r", encoding="utf-8") as fread:
+        content = fread.read()
+
+        content, changed = normalize(content)
+        if changed:
+            logger.info("The file %s has/will be normalized.", path)
+
+            if fail_if_changed:
+                raise FailOnChangeError("The file was changed.")
+
+            # Didn't fail and file has changed, so write to file.
+            with open(
+                output_filename if output_filename else path, "w", encoding="utf-8"
+            ) as fwrite:
+                fwrite.write(content)
+
+    if generate_formats:
+        logger.info("Writing Turtle file to N-Triples, N3, RDF/XML and JSON-LD.")
+        graph = Graph()
+        graph.parse(data=content, format="turtle")
+
+        formats = (
+            ("nt", "nt"),
+            ("n3", "n3"),
+            ("xml", "xml"),
+            ("json-ld", "jsonld"),
+        )
+        for format_ in formats:
+            filename_without_file_extension = get_filename_without_extension(
+                output_filename if output_filename else path
+            )
+            logger.info("Writing %s.%s", filename_without_file_extension, format_[1])
+            graph.serialize(
+                f"{filename_without_file_extension}.{format_[1]}", format=format_[0]
+            )
+
+    return changed

--- a/ontotools/utils.py
+++ b/ontotools/utils.py
@@ -1,3 +1,3 @@
 def get_filename_without_extension(file_name):
-    split_value = file_name.split(".")
+    split_value = str(file_name).split(".")
     return ".".join(split_value[:-1])

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ontotools",
-    version="0.4.0",
+    version="0.5.0",
     author="Edmond Chuc",
     author_email="e.chuc@uq.edu.au",
     description="Python ontology tools.",

--- a/tests/data/not_normalized_file.ttl
+++ b/tests/data/not_normalized_file.ttl
@@ -1,0 +1,25 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix tern: <https://w3id.org/tern/ontologies/tern/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://rs.tdwg.org/dwc/terms/materialSampleID>
+  a rdf:Property ;
+  rdfs:comment "An identifier for the MaterialSample (as opposed to a particular digital record of the material sample). In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the materialSampleID globally unique." ;
+  rdfs:isDefinedBy <http://rs.tdwg.org/dwc/terms/> ;
+  rdfs:label "material sample ID" ;
+.
+sosa:isSampleOf
+  a owl:TransitiveProperty ;
+.

--- a/tests/test_filename_wo_extension.py
+++ b/tests/test_filename_wo_extension.py
@@ -1,12 +1,16 @@
+import pytest
+
 from ontotools.utils import get_filename_without_extension
 
 
-def test_filename_wo_extension():
-    files = (
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
         ("ontology.nt", "ontology"),
         ("ontology.shacl.nt", "ontology.shacl"),
         ("ontology.1.0.0.nt", "ontology.1.0.0"),
-    )
-
-    for file in files:
-        assert get_filename_without_extension(file[0]) == file[1]
+        ("/workspaces/ontotools/ontology.nt", "/workspaces/ontotools/ontology"),
+    ],
+)
+def test_filename_wo_extension(filename, expected):
+    assert get_filename_without_extension(filename) == expected

--- a/tests/test_normalize_file.py
+++ b/tests/test_normalize_file.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from ontotools.functions.normalize_file import (
+    normalize_file,
+    FailOnChangeError,
+    normalize,
+)
+
+parent_path = Path(__file__).resolve().parent
+data_path = parent_path / "data"
+
+
+@pytest.fixture
+def output_path():
+    path = parent_path / "output_dir"
+    path.mkdir(exist_ok=True)
+    yield path
+
+    # Clean up.
+    files = [file for file in path.glob("**/*")]
+    for file in files:
+        file.unlink()
+    path.rmdir()
+
+
+@pytest.fixture
+def filepath():
+    return data_path / "not_normalized_file.ttl"
+
+
+def test_normalize_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        normalize_file(data_path / "non_existent_file.ttl", False, False)
+
+
+def test_normalize_with_fail_flag_will_raise(filepath: Path):
+    with pytest.raises(FailOnChangeError):
+        normalize_file(filepath, True, False)
+
+
+def test_normalize_file(filepath: Path, output_path: Path):
+    output_file = output_path / "output.ttl"
+    normalize_file(filepath, False, False, output_filename=output_file)
+
+    with open(output_file, "r", encoding="utf-8") as f:
+        output_content = f.read()
+        _, changed = normalize(output_content)
+        assert not changed
+
+
+def test_normalize_file_generate_formats(filepath: Path, output_path: Path):
+    output_file = output_path / "output.ttl"
+    normalize_file(filepath, False, True, output_filename=output_file)
+
+    files = [file for file in output_path.iterdir() if file.is_file()]
+
+    assert len(files) == 5
+    assert output_path / "output.ttl" in files
+    assert output_path / "output.nt" in files
+    assert output_path / "output.n3" in files
+    assert output_path / "output.jsonld" in files
+    assert output_path / "output.xml" in files


### PR DESCRIPTION
- Added additional tests for business logic of normalize-related functions.
- Refactored some code related to normalize file command to make it reusable and easier to write tests for.
- Added new command `ontotools dir normalize` which normalizes all the files in a directory. 