### PR TITLE
Change terminology from `--fail-if-changed` to `--check` for normalize commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ The tool currently normalises ontologies in the Turtle format for version contro
 
 ```bash
 $ ontotools file normalize --help
-Usage: ontotools file normalize [OPTIONS] FILENAME
+Usage: ontotools file normalize [OPTIONS] FILENAME [OUTPUT_FILENAME]
 
 Arguments:
-  FILENAME  The Turtle file to be normalized  [required]
+  FILENAME           The Turtle file to be normalized  [required]
+  [OUTPUT_FILENAME]  Output filename
 
 Options:
-  --fail-if-changed / --no-fail-if-changed
-                                  Fail if the file was changed  [default: no-
-                                  fail-if-changed]
+  --check / --no-check            Check if the file will change without
+                                  applying the effect  [default: no-check]
   --generate-formats / --no-generate-formats
                                   Generate other RDF formats (nt, n3, xml,
                                   jsonld)  [default: no-generate-formats]

--- a/ontotools/commands/directory.py
+++ b/ontotools/commands/directory.py
@@ -13,11 +13,13 @@ def normalize(
     directory: str = typer.Argument(
         ..., help="The directory of Turtle files to be normalized"
     ),
-    fail_if_changed: bool = typer.Option(False, help="Fail if files would changed"),
+    check: bool = typer.Option(
+        False, help="Check what files will be normalized without applying the effect."
+    ),
 ):
     """Normalizes the format of Turtle files in a given directory."""
     try:
-        normalize_dir(directory, fail_if_changed)
+        normalize_dir(directory, check)
     except FailOnChangeError as err:
         logger.error(err)
         sys.exit(1)

--- a/ontotools/commands/file.py
+++ b/ontotools/commands/file.py
@@ -15,14 +15,16 @@ app = typer.Typer()
 def normalize(
     filename: str = typer.Argument(..., help="The Turtle file to be normalized"),
     output_filename: Optional[str] = typer.Argument(None, help="Output filename"),
-    fail_if_changed: bool = typer.Option(False, help="Fail if the file was changed"),
+    check: bool = typer.Option(
+        False, help="Check if the file will change without applying the effect"
+    ),
     generate_formats: bool = typer.Option(
         False, help="Generate other RDF formats (nt, n3, xml, jsonld)"
     ),
 ):
     try:
         normalize_file(
-            filename, fail_if_changed, generate_formats, output_filename=output_filename
+            filename, check, generate_formats, output_filename=output_filename
         )
     except (FileNotFoundError, FailOnChangeError) as err:
         logger.error(err)

--- a/ontotools/functions/normalize_dir.py
+++ b/ontotools/functions/normalize_dir.py
@@ -17,7 +17,8 @@ def normalize_dir(path: Path, fail_if_changed: bool):
 
             if changed:
                 changed_files.append(file)
-        except FailOnChangeError:
+        except FailOnChangeError as err:
+            logger.info(err)
             changed_files.append(file)
 
     if fail_if_changed:

--- a/ontotools/functions/normalize_dir.py
+++ b/ontotools/functions/normalize_dir.py
@@ -4,7 +4,7 @@ from ontotools.functions.normalize_file import normalize_file, FailOnChangeError
 from ontotools.logging import logger
 
 
-def normalize_dir(path: Path, fail_if_changed: bool):
+def normalize_dir(path: Path, check: bool):
     path = Path(path).resolve()
 
     files = list(path.glob("**/*.ttl"))
@@ -13,7 +13,7 @@ def normalize_dir(path: Path, fail_if_changed: bool):
 
     for file in files:
         try:
-            changed = normalize_file(file, fail_if_changed, False)
+            changed = normalize_file(file, check, False)
 
             if changed:
                 changed_files.append(file)
@@ -21,7 +21,7 @@ def normalize_dir(path: Path, fail_if_changed: bool):
             logger.info(err)
             changed_files.append(file)
 
-    if fail_if_changed:
+    if check:
         raise FailOnChangeError(
             f"{len(changed_files)} out of {len(files)} files will change."
         )

--- a/ontotools/functions/normalize_file.py
+++ b/ontotools/functions/normalize_file.py
@@ -29,10 +29,10 @@ def normalize_file(
 
         content, changed = normalize(content)
         if changed:
-            logger.info("The file %s has/will be normalized.", path)
-
             if fail_if_changed:
-                raise FailOnChangeError("The file was changed.")
+                raise FailOnChangeError(f"The file {path} contains changes that can be normalized.")
+            else:
+                logger.info("The file %s has been normalized.", path)
 
             # Didn't fail and file has changed, so write to file.
             with open(

--- a/ontotools/functions/normalize_file.py
+++ b/ontotools/functions/normalize_file.py
@@ -15,7 +15,7 @@ class FailOnChangeError(Exception):
 
 def normalize_file(
     filename: pathlib.Path,
-    fail_if_changed: bool,
+    check: bool,
     generate_formats: bool,
     output_filename: pathlib.Path = None,
 ) -> bool:
@@ -29,7 +29,7 @@ def normalize_file(
 
         content, changed = normalize(content)
         if changed:
-            if fail_if_changed:
+            if check:
                 raise FailOnChangeError(f"The file {path} contains changes that can be normalized.")
             else:
                 logger.info("The file %s has been normalized.", path)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ontotools",
-    version="0.5.0",
+    version="0.6.0",
     author="Edmond Chuc",
     author_email="e.chuc@uq.edu.au",
     description="Python ontology tools.",


### PR DESCRIPTION
Additionally, add nicer logging for `ontotools dir normalize` when `--check` is used. Shows the files that will be changed.