### PR TITLE
Bound new prefixes `urnc` and `urnp`

### DIFF
--- a/ontotools/graph.py
+++ b/ontotools/graph.py
@@ -2,10 +2,14 @@ from rdflib import Graph, Namespace
 
 
 TERN = Namespace("https://w3id.org/tern/ontologies/tern/")
+URNC = Namespace("urn:class:")
+URNP = Namespace("urn:property:")
 
 
 def serialize(graph: Graph) -> str:
     # Reading files overrides pre-bound prefixes in RDFLib graphs.
     # This serialize function will bind the prefixes before serializing
     graph.bind("tern", TERN)
+    graph.bind("urnc", URNC)
+    graph.bind("urnp", URNP)
     return graph.serialize(format="longturtle")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ontotools",
-    version="0.6.1",
+    version="0.6.2",
     author="Edmond Chuc",
     author_email="e.chuc@uq.edu.au",
     description="Python ontology tools.",


### PR DESCRIPTION
`urnc` is `urn:class:`
`urnp` is `urn:property:`